### PR TITLE
Store remote ip on contact sign up

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -12,6 +12,6 @@ class ContactsController < ApplicationController
   private
 
   def contact_params
-    params.require(:contact).permit(:email)
+    params.require(:contact).permit(:email).merge(remote_ip: request.remote_ip)
   end
 end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe ContactsController, type: :controller do
+  describe 'POST #create' do
+    let(:http_params) { attributes_for :contact }
+
+    subject { post :create, params: { contact: http_params }, format: :js }
+
+    it_behaves_like 'successful request'
+    it_behaves_like 'action that is allowed for guests'
+
+    context 'with valid params' do
+      it 'creates a new contact' do
+        expect{ subject }.to change(Contact, :count).by 1
+      end
+    end
+
+    context 'with invalid params' do
+      let(:http_params) { { email: 'invalid@email' } }
+
+      it 'does not create a new contact' do
+        expect{ subject }.not_to change(Contact, :count)
+      end
+    end
+  end
+end

--- a/spec/features/contacts/collecting_emails_spec.rb
+++ b/spec/features/contacts/collecting_emails_spec.rb
@@ -2,12 +2,14 @@ require 'rails_helper'
 
 RSpec.feature 'collecting email addresses from the home page', js: true do
   scenario 'someone submits a valid email' do
+    allow_any_instance_of(ActionDispatch::Request).to receive(:remote_ip).and_return('1.2.3.4')
     visit root_path
 
     fill_form :contact, 'Your email address': 'valid@email.com'
     click_button 'Keep me posted'
 
     expect(page).to have_content 'Thanks for signing up!'
+    expect(Contact.last.remote_ip).to eq '1.2.3.4'
   end
 
   scenario 'someone submits an invalid or duplicate email' do


### PR DESCRIPTION
So we have a digital signature that counts as approval