### PR TITLE
Move the buttons up above the calendar on community events index

### DIFF
--- a/app/assets/javascripts/refills/accordion_tabs.js
+++ b/app/assets/javascripts/refills/accordion_tabs.js
@@ -1,6 +1,6 @@
 $(document).ready(function () {
   $('.accordion-tabs').each(function(index) {
-    $(this).children('li').first().children('a').addClass('is-active').next().addClass('is-open').show();
+    $(this).children('li').first().next().children('a').addClass('is-active').next().addClass('is-open').show();
   });
   $('.accordion-tabs').on('click', 'li > a.tab-link', function(event) {
     if (!$(this).hasClass('is-active')) {

--- a/app/assets/stylesheets/layout/community_events.scss
+++ b/app/assets/stylesheets/layout/community_events.scss
@@ -36,13 +36,13 @@
     }
   }
 
- .accordion-tabs {
+  .accordion-tabs {
     margin-top: 0;
   }
 
   .calendar-buttons {
     @include flex-column-then-row;
-    padding: $xl-space 0;
+    padding-top: $large-space;
 
     a {
       flex: 1;

--- a/app/views/community_events/index.html.erb
+++ b/app/views/community_events/index.html.erb
@@ -4,6 +4,11 @@
   <h1><%= t('.community_events') %></h1>
   <p><%= t('.community_events_description') %></p>
 
+  <div class='calendar-buttons'>
+    <a href=<%= COMMUNITY_CALENDAR[:url] %> target='_blank' class='button calendar'><%= t('.get_the_calendar') %></a>
+    <a href=<%= COMMUNITY_CALENDAR[:add] %> target='_blank' class='button calendar-add'><%= t('.add_your_event') %></a>
+  </div>
+
   <div class='date-nav'>
     <%= link_to url_for(date: @date.last_week(:sunday)), class: 'previous' do %>
       <span class='text'>Previous</span>
@@ -43,9 +48,4 @@
       </li>
     <% end %>
   </ul>
-
-  <div class='calendar-buttons'>
-    <a href=<%= COMMUNITY_CALENDAR[:url] %> target='_blank' class='button calendar'><%= t('.get_the_calendar') %></a>
-    <a href=<%= COMMUNITY_CALENDAR[:add] %> target='_blank' class='button calendar-add'><%= t('.add_your_event') %></a>
-  </div>
 </div>


### PR DESCRIPTION
The two red buttons at the bottom should be above the calendar, not under, for better visibility.