### PR TITLE
Previous link on community events cal doesn't work

### DIFF
--- a/app/views/community_events/index.html.erb
+++ b/app/views/community_events/index.html.erb
@@ -11,7 +11,7 @@
 
   <div class='date-nav'>
     <%= link_to url_for(date: @date.last_week.beginning_of_week(:sunday)), class: 'previous' do %>
-      <span class='text'>Previous</span>
+      <span class='text'><%= t('previous') %></span>
     <% end %>
 
     <% from = l(@events_by_date.keys.first, format: :short) %>
@@ -19,7 +19,7 @@
     <h2><%= from %> - <%= to %></h2>
 
     <%= link_to  url_for(date: @date.next_week(:sunday)), class: 'next' do %>
-      <span class='text'>Next</span>
+      <span class='text'><%= t('next') %></span>
     <% end %>
   </div>
 

--- a/app/views/community_events/index.html.erb
+++ b/app/views/community_events/index.html.erb
@@ -10,7 +10,7 @@
   </div>
 
   <div class='date-nav'>
-    <%= link_to url_for(date: @date.last_week(:sunday)), class: 'previous' do %>
+    <%= link_to url_for(date: @date.last_week.beginning_of_week(:sunday)), class: 'previous' do %>
       <span class='text'>Previous</span>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -146,3 +146,5 @@ en:
     '4': Thursday
     '5': Friday
     '6': Saturday
+  next: Next
+  previous: Previous


### PR DESCRIPTION
You have to click it twice, the first time is takes you to the same date range that you're already viewing.